### PR TITLE
Strip and ignore fancier markdown link types and liquid tags

### DIFF
--- a/src/markspelling.py
+++ b/src/markspelling.py
@@ -44,6 +44,10 @@ class MarkSpelling(object):
         self.regexhtmlclean = re.compile(r'\`.+?\`')
         self.regexlink = re.compile(r'\[(.+?)\]\(.+?\)')
         self.regexurl = re.compile(r'https?://\S+')
+        self.regexlinkid = re.compile(r'\[\S+\]:\s[^{\s]*')
+        self.regexlinkparam = re.compile(r'{:\S+="\S+"}')
+        self.regexliquidtag = re.compile(r'{%.+%}')
+        self.regexliquidobject = re.compile(r'{{.+}}')
 
     def checkcodeblock(self, line, incodeblock):
         if line.startswith('```') or line == '---':
@@ -61,8 +65,13 @@ class MarkSpelling(object):
             self.logger.debug(_DEBUG_FORMAT, linenumber, 'RAW', _ANSI_GRAY, line, _ANSI_RESET)
             line = self.regexhtmldirty.sub('', line)  # strip html tags
             line = self.regexhtmlclean.sub('', line)  # strip inline code
-            line = self.regexlink.sub(r'\1', line)  # strip links
+            line = self.regexlinkid.sub('', line)  # strip link ids
+            line = self.regexlinkparam.sub('', line)  # strip link params
+            line = self.regexlink.sub(r'\1', line)  # strip basic links
             line = self.regexurl.sub('', line)  # strip URLs
+            # if we were to detect liquid comment blocks, we should do it here
+            line = self.regexliquidtag.sub('', line)  # strip liquid tags
+            line = self.regexliquidobject.sub('', line)  # strip liquid objects
             line = line.strip()
             self.logger.debug(_DEBUG_FORMAT, linenumber, 'CLEAN', '', line, '')
             self.spellcheck.set_text(line)

--- a/src/testfile.md
+++ b/src/testfile.md
@@ -2,6 +2,8 @@
 speling: bad
 ---
 
+{{ phantum.sctn }}
+
 # Decoupling Sensor Networks by analysis of Congestion Control
 
 RAID and web browsers, while extensive in theory, have not until recently been considered key. In fact, few analysts would disagree with the deployment of context-free grammar, which embodies the theoretical principles of programming languages. In order to accomplish this goal, we use bimodal models to demonstrate that write-ahead logging and simulated annealing can interfere to overcome this problem.
@@ -17,4 +19,17 @@ for err in self.spellcheck:
     self.logger.debug("'%s' not found in main dictionary", err.word)
 ```
 
-In order to address this issue, we use compact modalities to show that evolutionary programming and architecture can collaborate to fix this quandary. However, embedded communication might not be the panacea that biologists expected. Furthermore, existing commutable and cooperative algorithms use loss-less communication to locate the deployment of the transistor. Though prior solutions to this grand challenge are good, none have taken the trainable solution we propose here. Though conventional wisdom states that this challenge is usually solved by the study of thin clients, we believe that a different approach is necessary. Combined with remote procedure calls, it presents an analysis of reinforcement learning.
+In order to address this issue, we use [compact modalities](/modalities/compactiful.htm) to show that evolutionary programming and architecture can collaborate to fix this quandary. However, embedded communication might not be the panacea that biologists expected. Furthermore, existing commutable and cooperative algorithms use loss-less communication to locate the deployment of the transistor. Though prior solutions to this grand challenge are good, none have taken the trainable solution we propose here. Though conventional wisdom states that this challenge is usually solved by the study of thin clients, we believe that a different approach is necessary. Combined with remote procedure calls, it presents an analysis of reinforcement learning.
+
+{% comment %}
+this is a comment line
+or paragraph, it has to
+be spelled correctly
+{% endcomment %}
+
+[technical_fooblyness]: /wersdiem/technical_details.html#jkfsdl
+
+[meeseeks]: {% link _development/00-meeseeks.md %}
+
+[docses]: http://docs.example.org/en/stable
+{:target="_docqments"}

--- a/src/tests.py
+++ b/src/tests.py
@@ -94,6 +94,16 @@ class TestFuncts(unittest.TestCase):
         self.assertEqual(self.markspell.checkline('Ignore <asd>bad tags</fgh>', 0, 'testcase.md', False), (0, False))
         self.assertEqual(self.markspell.checkline('Evrething <qwe>esle mattters</rty>', 0, 'testcase.md', False), (3, False))
 
+    def test_checkline_link(self):
+        """Test that link targets are ignored, but that spelling errors in the link are caught"""
+        self.assertEqual(self.markspell.checkline('This is a [good link](/bad/wurdz/ok/heer.tho)', 0, 'testcase.md', False), (0, False))
+        self.assertEqual(self.markspell.checkline('This link features [pooor speling](/bad/wurdz/ok/heer.tho)', 0, 'testcase.md', False), (2, False))
+
+    def test_liquid(self):
+        """Test that the contents of liquid tags and objects are ignored"""
+        self.assertEqual(self.markspell.checkline('This {% shood %} be fine', 0, 'testcase.md', False), (0, False))
+        self.assertEqual(self.markspell.checkline('Also {{ thees un }}', 0, 'testcase.md', False), (0, False))
+
     def test_checklinelist(self):
         """Check a list of lines for correct behaviour"""
         lines = [


### PR DESCRIPTION
Including use of liquid tags for magic

Resolves #9, apart from comment blocks which are hard and IMHO should be spellchecked anyway.